### PR TITLE
Adding export default for classes

### DIFF
--- a/src/BuildOutputPlugin.ts
+++ b/src/BuildOutputPlugin.ts
@@ -38,3 +38,5 @@ export class BuildOutputPlugin {
     }
   }
 }
+
+export default BuildOutputPlugin


### PR DESCRIPTION
So we could use both syntax:

```js
import { BuildOutputPlugin } from 'webpack-build-output'
import BuildOutputPlugin from 'webpack-build-output'
```